### PR TITLE
Upgrade to scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,9 +47,6 @@ lazy val compilerOptions = Seq(
   "-Wdead-code",
   "-Wvalue-discard"
 )
-// Add these back in when we can get to scala 2.13
-//  "-Wdead-code",
-//  "-Wvalue-discard",
 
 // Code coverage settings
 coverageMinimumStmtTotal := 70

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 import sbt._
 
-ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / scalaVersion := "2.13.7"
 ThisBuild / organization := "io.fluentlabs"
 ThisBuild / organizationName := "FluentLabs"
 
@@ -44,7 +44,8 @@ lazy val compilerOptions = Seq(
   "-feature",
   "-unchecked",
   "-Xfatal-warnings",
-  "-Ypartial-unification" // Remove me in scala 2.13
+  "-Wdead-code",
+  "-Wvalue-discard"
 )
 // Add these back in when we can get to scala 2.13
 //  "-Wdead-code",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val playWsStandaloneVersion: String = "2.1.3"
 
-  lazy val dto = "io.fluentlabs" % "dto" % "1.0.3"
+  lazy val dto = "io.fluentlabs" % "dto" % "1.0.4"
 
   lazy val opencc4j = "com.github.houbb" % "opencc4j" % "1.7.1"
   lazy val cats = "org.typelevel" %% "cats-core" % "2.6.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,8 +8,8 @@ object Dependencies {
   lazy val opencc4j = "com.github.houbb" % "opencc4j" % "1.7.1"
   lazy val cats = "org.typelevel" %% "cats-core" % "2.6.1"
   lazy val ws =
-    "com.typesafe.play" % "play-ahc-ws-standalone_2.13" % playWsStandaloneVersion
-  lazy val playJson = "com.typesafe.play" % "play-json_2.13" % "2.9.2"
+    "com.typesafe.play" %% "play-ahc-ws-standalone" % playWsStandaloneVersion
+  lazy val playJson = "com.typesafe.play" %% "play-json" % "2.9.2"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.10"
 
   lazy val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.32"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   lazy val opencc4j = "com.github.houbb" % "opencc4j" % "1.7.1"
   lazy val cats = "org.typelevel" %% "cats-core" % "2.6.1"
   lazy val ws =
-    "com.typesafe.play" %% "play-ahc-ws-standalone" % playWsStandaloneVersion
+    "com.typesafe.play" % "play-ahc-ws-standalone_2.13" % playWsStandaloneVersion
   lazy val playJson = "com.typesafe.play" % "play-json_2.13" % "2.9.2"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.10"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   lazy val cats = "org.typelevel" %% "cats-core" % "2.6.1"
   lazy val ws =
     "com.typesafe.play" %% "play-ahc-ws-standalone" % playWsStandaloneVersion
-  lazy val playJson = "com.typesafe.play" %% "play-json" % "2.9.2"
+  lazy val playJson = "com.typesafe.play" % "play-json_2.13" % "2.9.2"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.10"
 
   lazy val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.32"

--- a/src/main/scala/io/fluentlabs/content/enrichers/chinese/SimplifiedTraditionalConverter.scala
+++ b/src/main/scala/io/fluentlabs/content/enrichers/chinese/SimplifiedTraditionalConverter.scala
@@ -3,7 +3,7 @@ package io.fluentlabs.content.enrichers.chinese
 import com.github.houbb.opencc4j.util.ZhConverterUtil
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
 

--- a/src/main/scala/io/fluentlabs/content/types/internal/definition/ChineseDefinition.scala
+++ b/src/main/scala/io/fluentlabs/content/types/internal/definition/ChineseDefinition.scala
@@ -19,7 +19,7 @@ import io.fluentlabs.content.types.internal.word.PartOfSpeech
 import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json.{Json, Reads, Writes, __}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 
 case class ChineseDefinition(

--- a/src/main/scala/io/fluentlabs/content/types/internal/definition/EnglishDefinition.scala
+++ b/src/main/scala/io/fluentlabs/content/types/internal/definition/EnglishDefinition.scala
@@ -6,7 +6,7 @@ import io.fluentlabs.content.types.internal.word.PartOfSpeech.PartOfSpeech
 import io.fluentlabs.dto.v1.definition.DefinitionDTO
 import io.fluentlabs.content.types.internal.word.PartOfSpeech
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 case class EnglishDefinition(
     subdefinitions: List[String],

--- a/src/main/scala/io/fluentlabs/content/types/internal/definition/SpanishDefinition.scala
+++ b/src/main/scala/io/fluentlabs/content/types/internal/definition/SpanishDefinition.scala
@@ -6,7 +6,7 @@ import io.fluentlabs.content.types.internal.word.PartOfSpeech.PartOfSpeech
 import io.fluentlabs.dto.v1.definition.DefinitionDTO
 import io.fluentlabs.content.types.internal.word.PartOfSpeech
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 case class SpanishDefinition(
     subdefinitions: List[String],

--- a/src/test/scala/io/fluentlabs/content/types/internal/definition/ChineseDefinitionTest.scala
+++ b/src/test/scala/io/fluentlabs/content/types/internal/definition/ChineseDefinitionTest.scala
@@ -6,7 +6,7 @@ import io.fluentlabs.dto.v1.definition.chinese.HSKLevel
 import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 
 class ChineseDefinitionTest extends AnyFunSpec {


### PR DESCRIPTION
Spark is no longer stuck on scala 2.12, so let's get rid of a headache.